### PR TITLE
!hotfix parse  

### DIFF
--- a/src/bonus/includes/struct_bonus.h
+++ b/src/bonus/includes/struct_bonus.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   struct_bonus.h                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghwal <sanghwal@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/27 11:08:43 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/30 19:11:04 by sanghwal         ###   ########seoul.kr  */
+/*   Updated: 2023/07/03 14:30:07 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -246,6 +246,7 @@ struct						s_meta
 	t_thd_pool				thd_pool;
 	t_list					*spot_lights;
 	t_obj					*objs;
+	int						fd;
 };
 
 #endif

--- a/src/bonus/main_bonus.c
+++ b/src/bonus/main_bonus.c
@@ -6,7 +6,7 @@
 /*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 15:49:19 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/30 20:13:29 by jgo              ###   ########.fr       */
+/*   Updated: 2023/07/03 14:56:18 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,12 +20,26 @@
 #include "hooks_bonus.h"
 #include "thread_bonus.h"
 
+static bool	is_rtfile(char *file)
+{
+	char	*ext;
+
+	ext = ft_strrchr(file, '.');
+	if (!ext || ext == file)
+		return (false);
+	if (ft_strcmp(ext, ".rt"))
+		return (false);
+	return (true);
+}
+
 int	main(int ac, char **av)
 {
 	t_meta		*meta;
 
 	if (ac != 2)
 		error_handler(ARGS_ERR);
+	if (!is_rtfile(av[1]))
+		error_handler(EX_ERR);
 	parser(av[1]);
 	meta = singleton();
 	setup_scene(meta, WIN_WIDTH, WIN_HEIGHT);

--- a/src/bonus/parser_bonus/parser_bonus.c
+++ b/src/bonus/parser_bonus/parser_bonus.c
@@ -1,30 +1,19 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   parser.c                                           :+:      :+:    :+:   */
+/*   parser_bonus.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghwal <sanghwal@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/08 15:51:08 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/26 21:05:53 by sanghwal         ###   ########seoul.kr  */
+/*   Updated: 2023/07/03 14:59:11 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt_bonus.h"
 #include "parser_bonus.h"
 #include "utils_bonus.h"
-
-static bool	is_rtfile(char *file)
-{
-	char	*ext;
-
-	ext = ft_strrchr(file, '.');
-	if (!ext || ext == file)
-		return (false);
-	if (ft_strcmp(ext, ".rt"))
-		return (false);
-	return (true);
-}
+#include "design_patterns_bonus.h"
 
 static void	parser_router(char **temp)
 {
@@ -48,14 +37,15 @@ static void	parser_router(char **temp)
 
 void	parser(char *file)
 {
-	const int	fd = open(file, O_RDONLY);
+	int			fd;
 	char		*line;
 	char		**temp;
 
+	line = NULL;
+	fd = open(file, O_RDONLY);
 	if (fd < 0)
 		error_handler(OPEN_ERR);
-	if (!is_rtfile(file))
-		error_handler(EX_ERR);
+	singleton()->fd = fd;
 	line = get_next_line(fd);
 	while (line)
 	{
@@ -71,4 +61,5 @@ void	parser(char *file)
 		ft_free_all_arr(temp);
 		line = get_next_line(fd);
 	}
+	close(fd);
 }

--- a/src/bonus/utils_bonus/error_bonus.c
+++ b/src/bonus/utils_bonus/error_bonus.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   error_bonus.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghwal <sanghwal@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/09 19:52:57 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/30 19:35:15 by sanghwal         ###   ########seoul.kr  */
+/*   Updated: 2023/07/03 14:57:35 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,10 @@ static inline void	free_all(void)
 	meta = singleton();
 	ft_lstclear(&meta->spot_lights, free);
 	objs_clear(&meta->objs, free);
+	mlx_delete_image(meta->mlx_assets.mlx, meta->mlx_assets.img);
+	mlx_terminate(meta->mlx_assets.mlx);
+	if (meta->fd != -1)
+		close(meta->fd);
 	free(meta);
 }
 
@@ -36,7 +40,8 @@ static inline void	error_parser(t_error_type type)
 	[EX_ERR] = ERR_INVALID_EX, [TYPE_ERR] = ERR_INVALID_TYPE,
 	[AMB_ERR] = ERR_AMB, [LIGHT_ERR] = ERR_LIGHT, [CAM_ERR] = ERR_CAM,
 	[SP_ERR] = ERR_SP, [PL_ERR] = ERR_PL, [CY_ERR] = ERR_CY, [CO_ERR] = ERR_CO,
-	[POINT_ERR] = ERR_POINT, [VEC_ERR] = ERR_VEC, [RGB_ERR] = ERR_RGB
+	[POINT_ERR] = ERR_POINT, [VEC_ERR] = ERR_VEC, [RGB_ERR] = ERR_RGB,
+	[THD_ERR] = ERR_THD, [OPT_ERR] = ERR_OPT
 	};
 
 	if (type >= 0 && type < sizeof(error_msgs) / sizeof(error_msgs[0])
@@ -50,12 +55,10 @@ void	error_handler(t_error_type type)
 {
 	if (type == ARGS_ERR)
 		print_error_msg(ERR_ARGS);
-	if (type == OPEN_ERR)
+	else if (type == EX_ERR)
+		print_error_msg(ERR_INVALID_EX);
+	else if (type == OPEN_ERR)
 		print_error_msg(ERR_OPEN);
-	if (type == THD_ERR)
-		print_error_msg(ERR_THD);
-	if (type == OPT_ERR)
-		print_error_msg(ERR_OPT);
 	else
 		error_parser(type);
 	exit(EXIT_FAILURE);

--- a/src/mandatory/includes/struct.h
+++ b/src/mandatory/includes/struct.h
@@ -6,7 +6,7 @@
 /*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/27 11:08:43 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/30 10:39:31 by jgo              ###   ########.fr       */
+/*   Updated: 2023/07/03 14:26:04 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -172,6 +172,7 @@ struct						s_meta
 	t_hooks					hooks;
 	t_list					*spot_lights;
 	t_obj					*objs;
+	int						fd;
 };
 
 #endif

--- a/src/mandatory/includes/utils.h
+++ b/src/mandatory/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/27 11:09:46 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/29 10:05:51 by jgo              ###   ########.fr       */
+/*   Updated: 2023/07/03 14:53:01 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ t_rgb		rgba_min(t_rgb a, t_rgb b);
 double		atod(char *str);
 
 // error.c
-bool		error_handler(t_error_type type);
+void		error_handler(t_error_type type);
 
 // objs.c
 void		objsadd_back(t_obj **objs, t_obj *new);

--- a/src/mandatory/main.c
+++ b/src/mandatory/main.c
@@ -6,7 +6,7 @@
 /*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 15:49:19 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/30 20:13:01 by jgo              ###   ########.fr       */
+/*   Updated: 2023/07/03 14:59:01 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,26 @@
 #include "render.h"
 #include "hooks.h"
 
+static bool	is_rtfile(char *file)
+{
+	char	*ext;
+
+	ext = ft_strrchr(file, '.');
+	if (!ext || ext == file)
+		return (false);
+	if (ft_strcmp(ext, ".rt"))
+		return (false);
+	return (true);
+}
+
 int	main(int ac, char **av)
 {
-	t_meta		*meta;
+	t_meta	*meta;
 
 	if (ac != 2)
-		return (error_handler(ARGS_ERR));
+		error_handler(ARGS_ERR);
+	if (!is_rtfile(av[1]))
+		error_handler(EX_ERR);
 	parser(av[1]);
 	meta = singleton();
 	setup_scene(meta, WIN_WIDTH, WIN_HEIGHT);

--- a/src/mandatory/parser/parser.c
+++ b/src/mandatory/parser/parser.c
@@ -3,28 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghwal <sanghwal@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/08 15:51:08 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/18 20:05:47 by sanghwal         ###   ########seoul.kr  */
+/*   Updated: 2023/07/03 14:50:32 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 #include "parser.h"
 #include "utils.h"
-
-static bool	is_rtfile(char *file)
-{
-	char	*ext;
-
-	ext = ft_strrchr(file, '.');
-	if (!ext || ext == file)
-		return (false);
-	if (ft_strcmp(ext, ".rt"))
-		return (false);
-	return (true);
-}
+#include "design_patterns.h"
 
 static void	parser_router(char **temp)
 {
@@ -46,15 +35,15 @@ static void	parser_router(char **temp)
 
 void	parser(char *file)
 {
-	const int	fd = open(file, O_RDONLY);
+	int			fd;
 	char		*line;
 	char		**temp;
 
-	line = 0;
+	line = NULL;
+	fd = open(file, O_RDONLY);
 	if (fd < 0)
 		error_handler(OPEN_ERR);
-	if (!is_rtfile(file))
-		error_handler(EX_ERR);
+	singleton()->fd = fd;
 	line = get_next_line(fd);
 	while (line)
 	{
@@ -70,4 +59,5 @@ void	parser(char *file)
 		ft_free_all_arr(temp);
 		line = get_next_line(fd);
 	}
+	close(fd);
 }

--- a/src/mandatory/utils/error.c
+++ b/src/mandatory/utils/error.c
@@ -3,16 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   error.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghwal <sanghwal@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jgo <jgo@student.42seoul.fr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/09 19:52:57 by jgo               #+#    #+#             */
-/*   Updated: 2023/06/18 20:12:25 by sanghwal         ###   ########seoul.kr  */
+/*   Updated: 2023/07/03 14:52:48 by jgo              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minirt.h"
 #include "defs.h"
 #include "design_patterns.h"
+#include "minirt.h"
 #include "utils.h"
 
 static inline void	print_error_msg(char *msg)
@@ -27,6 +27,10 @@ static inline void	free_all(void)
 	meta = singleton();
 	ft_lstclear(&meta->spot_lights, free);
 	objs_clear(&meta->objs, free);
+	mlx_delete_image(meta->mlx_assets.mlx, meta->mlx_assets.img);
+	mlx_terminate(meta->mlx_assets.mlx);
+	if (meta->fd != -1)
+		close(meta->fd);
 	free(meta);
 }
 
@@ -50,21 +54,21 @@ static inline void	error_parser(t_error_type type)
 		print_error_msg(ERR_VEC);
 	if (type == RGB_ERR)
 		print_error_msg(ERR_RGB);
-	if (type == EX_ERR)
-		print_error_msg(ERR_INVALID_EX);
 	if (type == TYPE_ERR)
 		print_error_msg(ERR_INVALID_TYPE);
 	free_all();
 	exit(EXIT_FAILURE);
 }
 
-bool	error_handler(t_error_type type)
+void	error_handler(t_error_type type)
 {
 	if (type == ARGS_ERR)
 		print_error_msg(ERR_ARGS);
-	if (type == OPEN_ERR)
+	else if (type == EX_ERR)
+		print_error_msg(ERR_INVALID_EX);
+	else if (type == OPEN_ERR)
 		print_error_msg(ERR_OPEN);
 	else
 		error_parser(type);
-	return (EXIT_FAILURE);
+	exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

첫번째 평가를 받은 후 parser에서 난 에러를 수정하였습니다. 
변경내용은 존재하지 않는 .rt파일이 붙은 인자값이 들어왔을 때 에러 메시지는 출력하지만 mlx window가 띄워지는 버그였습니다. 
이를 수정하여 에러 메시지를 출력하고 프로그램이 종료되게 하였습니다. 또한, close하지 않은 fd값 처리도 함께 하였습니다. 
